### PR TITLE
Support merge commit

### DIFF
--- a/git.go
+++ b/git.go
@@ -19,6 +19,15 @@ func (c CLI) currentCommit() (*object.Commit, error) {
 	return c.Repo.CommitObject(ref.Hash())
 }
 
+func (c CLI) previousCommit() (*object.Commit, error) {
+	hash, err := c.Repo.ResolveRevision("HEAD^")
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Repo.CommitObject(*hash)
+}
+
 func (c CLI) remoteCommit(name string) (*object.Commit, error) {
 	refs, err := c.Repo.References()
 	if err != nil {


### PR DESCRIPTION
## WHAT

Support merge commit

## WHY

Currently, this command can show the diff between master and topic branch (e.g. On the pull request). But it doesn't work on master branch (main branch) after merged topic branch. So support it

```console
$ # On main branch
$ LOG=trace changed-objects --filter=modified --filter=added --default-branch main -o json
2022/04/13 01:27:55 [INFO] Version: unset (unset)
2022/04/13 01:27:55 [INFO] Args: []string{"--filter=modified", "--filter=added", "--default-branch", "main", "-o", "json"}
2022/04/13 01:27:55 [INFO] git repo: /Users/babarot/src/github.com/babarot/infrastructure
2022/04/13 01:27:55 [TRACE] getting HEAD: main
2022/04/13 01:27:55 [DEBUG] refs/heads/main: get commit
2022/04/13 01:27:55 [DEBUG] a number of changes: 3
2022/04/13 01:27:55 [DEBUG] stat: main.Stat{Kind:0, Path:"terraform/services/babarot-infra/production/backend.tf"}
2022/04/13 01:27:55 [DEBUG] stat: main.Stat{Kind:0, Path:"terraform/services/babarot-infra/production/google_storage_bucket.tf"}
2022/04/13 01:27:55 [DEBUG] stat: main.Stat{Kind:0, Path:"terraform/services/babarot-infra/production/module_gcp_kit.tf"}
2022/04/13 01:27:55 [DEBUG] filters: []string{"modified", "added"}
{"repo":"/Users/babarot/src/github.com/babarot/infrastructure","stats":[{"kind":"insert","path":"terraform/services/babarot-infra/production/backend.tf"},{"kind":"insert","path":"terraform/services/babarot-infra/production/google_storage_bucket.tf"},{"kind":"insert","path":"terraform/services/babarot-infra/production/module_gcp_kit.tf"}]}
2022/04/13 01:27:55 [INFO] finish main function
```