### PR TITLE
Change the behavior on args

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,11 @@ jobs:
         with:
           labels: ${{ steps.get-merged-pull-request.outputs.labels }}
 
+      - name: Workaround for Git vulnerability
+        run: |
+          # https://github.blog/2022-04-12-git-security-vulnerability-announced/
+          git config --global --add safe.directory /github/workspace
+
       - name: Get latest Git tag
         uses: actions-ecosystem/action-get-latest-tag@v1
         id: get-latest-tag

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,6 @@ go 1.13
 require (
 	github.com/b4b4r07/go-cli-log v0.0.0-20200124120248-8fac4d71de01
 	github.com/jessevdk/go-flags v1.4.0
+	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1
 )

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,9 @@ golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e h1:D5TXcfTk7xF7hvieo4QErS3qqCB4teTffacDWr7CI+0=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 h1:foEbQz/B0Oz6YIqu/69kfXPYeFQAuuMYFkjaqXzl5Wo=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=


### PR DESCRIPTION
## WHAT

Before:
args are not working before (just specifying repo path)

After:
args means directory paths to filter out

## WHY

Want to specify directories to run this command:

```console
$ LOG=trace changed-objects --filter=modified --filter=added --default-branch main -o json terraform
2022/04/13 16:59:22 [INFO] Version: unset (unset)
2022/04/13 16:59:22 [INFO] Args: []string{"--filter=modified", "--filter=added", "--default-branch", "main", "-o", "json", "terraform"}
2022/04/13 16:59:22 [INFO] git repo: /Users/babarot/src/github.com/babarot/infrastructure
2022/04/13 16:59:22 [TRACE] getting HEAD: babarot/px-infar/module
2022/04/13 16:59:22 [DEBUG] refs/remotes/origin/main: get commit
2022/04/13 16:59:22 [DEBUG] refs/heads/babarot/px-infar/module: get commit
2022/04/13 16:59:22 [DEBUG] a number of changes: 2
2022/04/13 16:59:22 [DEBUG] stat: main.Stat{Kind:2, Path:".github/workflows/make_gcp_project.yaml"}
2022/04/13 16:59:22 [DEBUG] stat: main.Stat{Kind:2, Path:"terraform/services/px-infar/production/module_gcp_kit.tf"}
2022/04/13 16:59:22 [DEBUG] filters: []string{"modified", "added"}
2022/04/13 16:59:22 [TRACE] filtering with "terraform" -1
2022/04/13 16:59:22 [TRACE] filtering with "terraform" 0
{"repo":"/Users/babarot/src/github.com/babarot/infrastructure","stats":[{"kind":"modify","path":"terraform/services/px-infar/production/module_gcp_kit.tf"}]}
2022/04/13 16:59:22 [INFO] finish main function
```