### PR TITLE
Add merge-base option

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ type Option struct {
 	Dirname       bool     `long:"dirname" description:"Return changed objects with their directory name"`
 	Output        string   `long:"output" short:"o" description:"Format to output the result" default:""`
 	DefaultBranch string   `long:"default-branch" description:"Specify default branch" default:"main"`
+	MergeBase     string   `long:"merge-base" description:"Specify merge-base revision (commitRev is current branch)"`
 
 	Version bool `short:"v" long:"version" description:"Show version"`
 }
@@ -99,6 +100,7 @@ func (c *CLI) Run(args []string) error {
 	log.Printf("[TRACE] getting HEAD: %s", branch)
 
 	var base *object.Commit
+
 	switch branch {
 	case c.Option.DefaultBranch:
 		log.Printf("[DEBUG] Getting previous HEAD commit")
@@ -114,6 +116,19 @@ func (c *CLI) Run(args []string) error {
 			return err
 		}
 		base = remote
+	}
+
+	if c.Option.MergeBase != "" {
+		log.Printf("[DEBUG] Comparing with merge-base")
+		h, err := c.Repo.Head()
+		if err != nil {
+			return err
+		}
+		currentBranch := h.Name().Short()
+		base, err = c.mergeBase(c.Option.MergeBase, currentBranch)
+		if err != nil {
+			return err
+		}
 	}
 
 	log.Printf("[DEBUG] Getting current commit")

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func (c *CLI) Run(args []string) error {
 	branch := strings.Replace(head.Name().String(), "refs/heads/", "", -1)
 	log.Printf("[TRACE] getting HEAD: %s", branch)
 
-	var commit *object.Commit
+	var base *object.Commit
 	switch branch {
 	case c.Option.DefaultBranch:
 		log.Printf("[DEBUG] Getting previous HEAD commit")
@@ -106,14 +106,14 @@ func (c *CLI) Run(args []string) error {
 		if err != nil {
 			return err
 		}
-		commit = prev
+		base = prev
 	default:
 		log.Printf("[DEBUG] Getting remote commit")
 		remote, err := c.remoteCommit("origin/" + c.Option.DefaultBranch)
 		if err != nil {
 			return err
 		}
-		commit = remote
+		base = remote
 	}
 
 	log.Printf("[DEBUG] Getting current commit")
@@ -122,7 +122,7 @@ func (c *CLI) Run(args []string) error {
 		return err
 	}
 
-	stats, err := c.getStats(commit, current)
+	stats, err := c.getStats(base, current)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## WHAT

Add merge-base option

## WHY

To use merge-base revision to list files only changed on branches

Before:
```console
$ changed-objects --filter=added --filter=modified --filter=deleted --dirname --output=json --default-branch=main terraform | jq .
{
  "repo": "/Users/babarot/src/github.com/baba-inc/infrastructure",
  "stats": [
    {
      "kind": "insert",
      "path": "terraform/services/foo/development"
    },
    {
      "kind": "insert",
      "path": "terraform/services/foo/production"
    },
    {
      "kind": "delete",
      "path": "terraform/services/bar/development"
    },
    {
      "kind": "delete",
      "path": "terraform/services/bar/production"
    },
    {
      "kind": "delete",
      "path": "terraform/services/baz/development"
    },
    {
      "kind": "delete",
      "path": "terraform/services/baz/production"
    }
  ]
}
```

After:
```console
$ changed-objects --filter=added --filter=modified --filter=deleted --dirname --output=json --default-branch=main --merge-base=main terraform | jq .
{
  "repo": "/Users/babarot/src/github.com/baba-inc/infrastructure",
  "stats": [
    {
      "kind": "insert",
      "path": "terraform/services/foo/development"
    },
    {
      "kind": "insert",
      "path": "terraform/services/foo/production"
    }
  ]
}
```