### PR TITLE
Add `--dir-exist` flag and `--dir-not-exist`

### DIFF
--- a/git.go
+++ b/git.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
@@ -104,6 +106,12 @@ func (c CLI) fileStatsFromChange(change *object.Change) (Stat, error) {
 	return Stat{
 		Kind: kind,
 		Path: path,
+		File: path,
+		Dir:  filepath.Dir(path),
+		DirExist: func() bool {
+			_, err := os.Stat(filepath.Dir(path))
+			return err == nil
+		}(),
 	}, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ type Option struct {
 	Filters       []string `long:"filter" description:"Filter the kind of changed objects" default:"all" choice:"added" choice:"modified" choice:"deleted" choice:"all"`
 	Dirname       bool     `long:"dirname" description:"Return changed objects with their directory name"`
 	DirExist      bool     `long:"dir-exist" description:"Return changed objects if parent dir exists"`
+	DirNotExist   bool     `long:"dir-not-exist" description:"Return changed objects if parent dir does not exist"`
 	Output        string   `long:"output" short:"o" description:"Format to output the result" default:"" choice:"json"`
 	DefaultBranch string   `long:"default-branch" description:"Specify default branch" default:"main"`
 	MergeBase     string   `long:"merge-base" description:"Specify merge-base revision"`
@@ -189,6 +190,12 @@ func (c *CLI) Run(args []string) error {
 	if c.Option.DirExist {
 		stats = stats.Filter(func(stat Stat) bool {
 			return stat.DirExist
+		})
+	}
+
+	if c.Option.DirNotExist {
+		stats = stats.Filter(func(stat Stat) bool {
+			return !stat.DirExist
 		})
 	}
 

--- a/stat.go
+++ b/stat.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"io"
 )
 
 type Kind int
@@ -33,20 +32,15 @@ func (k Kind) MarshalJSON() ([]byte, error) {
 
 // Stat represents the stats for a file in a commit.
 type Stat struct {
-	Kind Kind   `json:"kind"`
-	Path string `json:"path"`
+	Kind     Kind   `json:"kind"`
+	Path     string `json:"path"`
+	File     string `json:"file"`
+	Dir      string `json:"dir"`
+	DirExist bool   `json:"dir-exist"`
+	Output   string `json:"-"`
 }
 
 type Stats []Stat
-
-type Result struct {
-	Repo  string `json:"repo,omitempty"`
-	Stats Stats  `json:"stats,omitempty"`
-}
-
-func (r Result) Print(w io.Writer) error {
-	return json.NewEncoder(w).Encode(&r)
-}
 
 func (ss *Stats) Filter(f func(Stat) bool) Stats {
 	stats := make([]Stat, 0)
@@ -67,11 +61,11 @@ func (ss *Stats) Map(f func(Stat) Stat) Stats {
 }
 
 func (ss *Stats) Unique() Stats {
-	m := make(map[Stat]bool)
+	m := make(map[string]bool)
 	stats := make([]Stat, 0)
 	for _, stat := range *ss {
-		if !m[stat] {
-			m[stat] = true
+		if !m[stat.Path] {
+			m[stat.Path] = true
 			stats = append(stats, stat)
 		}
 	}


### PR DESCRIPTION
## WHAT

Add `--dir-exist` flag and `--dir-not-exist` to show directories even if the files stored in that dir are deleted.

```console
$ ls terraform/pagerduty
elasticsearch    babarot-corp

$ changed-objects --filter=all --default-branch=main --merge-base=origin/main -o json --dirname | jq '[.stats[].path]'
[
  "terraform/pagerduty/elasticsearch",
  "terraform/pagerduty/babarot-corp",
  "terraform/pagerduty/babarot-corp-delivery-and-purchase",
  "terraform/pagerduty/babarot-corp-master-import",
  "terraform/pagerduty/babarot-corp-staff",
  "terraform/pagerduty/babarot-corp-payments"
]

$ changed-objects --filter=all --default-branch=main --merge-base=origin/main -o json --dirname --dir-exist | jq '[.stats[].path]'
[
  "terraform/pagerduty/elasticsearch",
  "terraform/pagerduty/babarot-corp"
]

$ changed-objects --filter=deleted --default-branch=main --merge-base=origin/main -o json --dirname | jq '[.stats[].path]'
[
  "terraform/pagerduty/elasticsearch",
  "terraform/pagerduty/babarot-corp-delivery-and-purchase",
  "terraform/pagerduty/babarot-corp-master-import",
  "terraform/pagerduty/babarot-corp-staff",
  "terraform/pagerduty/babarot-corp-payments"
]

$ changed-objects --filter=deleted --default-branch=main --merge-base=origin/main -o json --dirname --dir-exist | jq '[.stats[].path]'
[
  "terraform/pagerduty/elasticsearch"
]

$ changed-objects --filter=deleted --default-branch=main --merge-base=origin/main -o json --dirname --dir-not-exist | jq '[.stats[].path]'
[
  "terraform/pagerduty/babarot-corp-delivery-and-purchase",
  "terraform/pagerduty/babarot-corp-master-import",
  "terraform/pagerduty/babarot-corp-staff",
  "terraform/pagerduty/babarot-corp-payments"
]
```

<!--
specified flag | what we can see by flag combinations
---|---
`--filter=all`, `--dir-exist` | existing files
`--filter=all`, `dir-exist`, `--dirname` | existing dirs
`--filter=deleted` | deleted files (cannot detect the parent dir is deleted or not)
-->



## WHY

Wanted to show only deleted directories. Strictly speaking, want to distinguish directories from deleted one and not deleted one even if the files located in that directory are deleted.