### PR TITLE
Add --parent-dir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,16 @@ Usage:
   changed-objects [OPTIONS]
 
 Application Options:
-  -v, --version                       Show version
-  -b, --default-branch=               Specify default branch name (default: main)
-  -m, --merge-base=                   Specify a Git reference as good common ancestors as possible for a merge
-      --type=[added|modified|deleted] Specify the type of changed objects
-      --ignore=                       Specify a pattern to skip when showing changed objects
-      --group-by=                     Specify a pattern to make into one group when showing changed objects
+  -v, --version                        Show version
+  -b, --default-branch=                Specify default branch name (default: main)
+  -m, --merge-base=                    Specify a Git reference as good common ancestors as possible for a merge
+      --type=[added|modified|deleted]  Specify the type of changed objects
+      --ignore=                        Specify a pattern to skip when showing changed objects
+      --group-by=                      Specify a pattern to make into one group when showing changed objects
+      --parent-dir=[exist|deleted|all] Filter objects by state of parent dir (default: all)
 
 Help Options:
-  -h, --help                          Show this help message
+  -h, --help                           Show this help message
 ```
 
 ## Usage

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ type Option struct {
 	Types         []string `long:"type" description:"Specify the type of changed objects" choice:"added" choice:"modified" choice:"deleted"`
 	Ignores       []string `long:"ignore" description:"Specify a pattern to skip when showing changed objects"`
 	GroupBy       string   `long:"group-by" description:"Specify a pattern to make into one group when showing changed objects"`
+	ParentDir     string   `long:"parent-dir" description:"Filter objects by state of parent dir" choice:"exist" choice:"deleted" choice:"all" default:"all"`
 }
 
 func main() {
@@ -72,6 +73,7 @@ func run(args []string) error {
 		Ignores:       opt.Ignores,
 		GroupBy:       opt.GroupBy,
 		Types:         opt.Types,
+		ParentDir:     opt.ParentDir,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## WHAT

Add `--parent-dir` flag to keep backward compatibility as much as possible

## WHY

Similar feature has been implemented in before version