### PR TITLE
Fix JSON output for empty results

### DIFF
--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -103,9 +103,19 @@ func (c client) Run() (Diff, error) {
 		}
 	})
 
+	files := c.getFiles(changes)
+	dirs := c.getDirs(changes)
+
+	if files == nil {
+		files = []File{}
+	}
+	if dirs == nil {
+		dirs = []Dir{}
+	}
+
 	return Diff{
-		Files: c.getFiles(changes),
-		Dirs:  c.getDirs(changes),
+		Files: files,
+		Dirs:  dirs,
 	}, nil
 }
 


### PR DESCRIPTION


### Problem
When running the `changed-objects` command with filters that return no results, the current JSON output is:
```json
{"files":null,"dirs":null}
```

However, the expected output should be:
```json
{"files":[],"dirs":[]}
```

This inconsistency can cause issues for consumers of the JSON output who expect empty arrays rather than null values.

### Solution
Modified the `Run()` method in `internal/detect/detect.go` to initialize empty slices instead of returning nil slices when no results are found. This ensures that the JSON output will always have empty arrays (`[]`) rather than null values when no files or directories match the filter criteria.

### Changes
- Added explicit checks for nil slices in the `Run()` method
- Added conversion from nil slices to empty slices before returning the result

This change maintains backward compatibility while ensuring consistent JSON output format.