### PR TITLE
feat: add --root-marker option to resolve Terraform module roots

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ type Option struct {
 	Ignores       []string `long:"ignore" description:"Specify a pattern to skip when showing changed objects"`
 	GroupBy       []string `long:"group-by" description:"Specify a pattern to make into one group when showing changed objects"`
 	DirExist      string   `long:"dir-exist" description:"Filter objects by state of dir existing" choice:"true" choice:"false" choice:"all" default:"all"`
+	RootMarker    string   `long:"root-marker" description:"Specify a glob pattern of file that marks the root directory (e.g. *.tf)"`
 }
 
 func main() {
@@ -85,6 +86,7 @@ func run(args []string) error {
 		GroupBy:       opt.GroupBy,
 		Types:         opt.Types,
 		DirExist:      opt.DirExist,
+		RootMarker:    opt.RootMarker,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## What

Add a new `--root-marker` flag that accepts a glob pattern (e.g. `*.tf`) and resolves each changed directory to the nearest ancestor directory containing a matching file.

- Add `RootMarker` field to `Option` struct in `detect.go` and `main.go`
- Add `findRootByMarker(dir, marker string) string` that walks parent directories using `getSteps()` and checks each directory for a file matching the marker pattern via `doublestar.Match`
- Apply the resolution as a post-processing step in `getDirs()`: if a marker is specified and no matching ancestor is found, the directory is silently skipped (deduplication is handled automatically via the map key)
- Add `Test_findRootByMarker` with 7 test cases covering: direct parent match, child subdirectory traversal, multi-level traversal, no match (skip), and alternative patterns

## Why

Non-`.tf` files (e.g. `.json`, `.sh`) changed under a Terraform module directory currently cause the workflow to either miss the plan or require a 23-line shell loop to walk up and find the nearest `.tf`-containing ancestor. That loop is duplicated across `terraform_plan.yaml` and `terraform_apply.yaml`, and cannot be unit-tested.

By absorbing this logic into the CLI, the workflow shell scripts can be simplified and the behavior becomes testable in Go.